### PR TITLE
Only download index files if they don't exist already in the cache directory

### DIFF
--- a/irsdb/filing/management/commands/enter_yearly_submissions.py
+++ b/irsdb/filing/management/commands/enter_yearly_submissions.py
@@ -28,9 +28,12 @@ class Command(BaseCommand):
 
             local_file_path = os.path.join(INDEX_DIRECTORY, "index_%s.csv" % year)
 
-            print('Downloading index_%s.csv...' % year)
-            stream_download(irs_file_url, local_file_path)
-            print('Done!')
+            if os.path.isfile(local_file_path):
+                print('Found index_%s.csv...' % year)
+            else:
+                print('Downloading index_%s.csv...' % year)
+                stream_download(irs_file_url, local_file_path)
+                print('Done!')
 
             print("Entering xml submissions from %s" % local_file_path)
             fh = open(local_file_path, 'r')


### PR DESCRIPTION
Avoiding repeated downloads of index files is desirable in itself, but it also allows manually fixing the [broken 2014 index file](https://github.com/jsfenfen/990-xml-reader/blob/master/2014_is_broken.md) before attempting to load it into the database.