### PR TITLE
Small Fixes for 2014 Index File Handling

### DIFF
--- a/irsdb/filing/management/commands/enter_yearly_submissions.py
+++ b/irsdb/filing/management/commands/enter_yearly_submissions.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
                     print("Error with line: {line}".format(line=line))
                     if year == 2014:
                         print('Did you fix the 2014 index file? See the README for instructions.')
-                    raise err
+                    raise
 
                 try:
                     obj = Filing.objects.get(object_id=object_id)

--- a/irsdb/filing/management/commands/enter_yearly_submissions.py
+++ b/irsdb/filing/management/commands/enter_yearly_submissions.py
@@ -42,7 +42,13 @@ class Command(BaseCommand):
             next(reader)
             count = 0
             for line in reader:
-                (return_id, filing_type, ein, tax_period, sub_date, taxpayer_name, return_type, dln, object_id) = line
+                try:
+                    (return_id, filing_type, ein, tax_period, sub_date, taxpayer_name, return_type, dln, object_id) = line
+                except ValueError as err:
+                    print("Error with line: {line}".format(line=line))
+                    if year == 2014:
+                        print('Did you fix the 2014 index file? See the README for instructions.')
+                    raise err
 
                 try:
                     obj = Filing.objects.get(object_id=object_id)

--- a/irsdb/filing/management/commands/enter_yearly_submissions.py
+++ b/irsdb/filing/management/commands/enter_yearly_submissions.py
@@ -13,7 +13,7 @@ BATCH_SIZE = 10000
 
 class Command(BaseCommand):
     help = '''
-    Read the yearly csv file line by line and add new lines if 
+    Read the yearly csv file line by line and add new lines if
     they don't exist. Lines are added in bulk at the end.
     '''
 
@@ -23,14 +23,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         for year in options['year']:
-            irs_file_url = 'https://s3.amazonaws.com/irs-form-990/index_%s.csv' % year
-            irs_file_len = 0
-
             local_file_path = os.path.join(INDEX_DIRECTORY, "index_%s.csv" % year)
 
-            print('Downloading index_%s.csv...' % year)
-            stream_download(irs_file_url, local_file_path)
-            print('Done!')
+            if not os.path.exists(local_file_path):
+                irs_file_url = 'https://s3.amazonaws.com/irs-form-990/index_%s.csv' % year
+                print('Downloading index_%s.csv...' % year)
+                stream_download(irs_file_url, local_file_path)
+                print('Done!')
 
             print("Entering xml submissions from %s" % local_file_path)
             fh = open(local_file_path, 'r')


### PR DESCRIPTION
I synced all data from S3 upfront and then starting loading filings, but my fixed 2014 index was overwritten. These changes prevent that (and print more informative errors when you hit the bad case).